### PR TITLE
fix: incorrect binding of controller funcs

### DIFF
--- a/angular-classy.coffee
+++ b/angular-classy.coffee
@@ -79,8 +79,10 @@ classFns =
     $scope = parent[parent.constructor::__options._scopeName]
     for key, fn of parent.constructor::
       continue unless angular.isFunction(fn)
-      continue if key in ['constructor', 'init', 'watch'] or key[0] is '_'
-      $scope[key] = angular.bind(parent, fn)
+      continue if key in ['constructor', 'init', 'watch']
+      parent[key] = angular.bind(parent, fn)
+      if key[0] isnt '_'
+        $scope[key] = parent[key]
 
   bindDependencies: (parent, args) ->
     injectObject = parent.__classyControllerInjectObject


### PR DESCRIPTION
- this properly binds the execution context of a function defined in a
  classy controller so that `this` references the controller
- allows access to injected dependencies and the proper reference when
  inside a promise success callback
- fixes https://github.com/davej/angular-classy/issues/8
